### PR TITLE
Fixed missing contol-plane selector

### DIFF
--- a/charts/kubeedge/templates/deployment.yaml
+++ b/charts/kubeedge/templates/deployment.yaml
@@ -37,6 +37,15 @@ spec:
                 operator: NotIn
                 values:
                 - windows
+              - key: node-role.kubernetes.io/control-plane
+                operator: In
+                values:
+                - "true"
+            - matchExpressions:
+              - key: beta.kubernetes.io/os
+                operator: NotIn
+                values:
+                - windows
               - key: node-role.kubernetes.io/master
                 operator: In
                 values:


### PR DESCRIPTION
This is needed, because in k8s both namings exist: 'control-plane' and 'controlplane' :-/