### PR TITLE
Added retries during cluster creation

### DIFF
--- a/hack/edge-node-config/ubuntu-22.04/unprovision.sh
+++ b/hack/edge-node-config/ubuntu-22.04/unprovision.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
-yurtadm reset -f
+
+# Try to reset via yurtadm first
+yurtadm --help > /dev/null 2>&1
+if [ $? -eq 0 ]; then
+  yurtadm reset -f
+else
+  # Try to reset via kubeadm as a fallback
+  kubeadm --help > /dev/null 2>&1
+  if [ $? -eq 0 ]; then
+    kubeadm reset -f
+  fi
+fi
 rm -rf /etc/cni/net.d
 ip link set cni0 down
 ip link delete cni0

--- a/pkg/k8s/crd.go
+++ b/pkg/k8s/crd.go
@@ -36,3 +36,21 @@ func CrdExists(name string) (bool, error) {
 	}
 	return false, nil
 }
+
+func CrdEstablished(name string) (bool, error) {
+	clientset, err := apiextensionsclientset.NewForConfig(getConfig())
+	if err != nil {
+		return false, err
+	}
+	crd, err := clientset.ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		return false, err
+	}
+
+	for _, cond := range crd.Status.Conditions {
+		if cond.Type == v1.Established && cond.Status == v1.ConditionTrue {
+			return true, nil
+		}
+	}
+	return false, nil
+}


### PR DESCRIPTION
There are cases when resources are updated right in between a "get the current state and update it" action during cluster creation. So retries have been added to handle these cases. 

Also the ubuntu 22.04 unprovision script now handles yurtadm and kubeadm.